### PR TITLE
Replace getIncrementalTransform() with getTransform()

### DIFF
--- a/GUI/src/MainController.cpp
+++ b/GUI/src/MainController.cpp
@@ -258,7 +258,7 @@ void MainController::run()
                 {
                     currentPose = new Eigen::Matrix4f;
                     currentPose->setIdentity();
-                    *currentPose = groundTruthOdometry->getIncrementalTransformation(logReader->timestamp);
+                    *currentPose = groundTruthOdometry->getTransformation(logReader->timestamp);
                 }
 
                 eFusion->processFrame(logReader->rgb, logReader->depth, logReader->timestamp, currentPose, weightMultiplier);

--- a/GUI/src/Tools/GroundTruthOdometry.cpp
+++ b/GUI/src/Tools/GroundTruthOdometry.cpp
@@ -56,7 +56,7 @@ void GroundTruthOdometry::loadTrajectory(const std::string & filename)
     }
 }
 
-Eigen::Matrix4f GroundTruthOdometry::getIncrementalTransformation(uint64_t timestamp)
+Eigen::Matrix4f GroundTruthOdometry::getTransformation(uint64_t timestamp)
 {
     Eigen::Matrix4f pose = Eigen::Matrix4f::Identity();
 
@@ -69,8 +69,6 @@ Eigen::Matrix4f GroundTruthOdometry::getIncrementalTransformation(uint64_t times
             return pose;
         }
 
-        Eigen::Isometry3f delta = camera_trajectory[last_utime].inverse() * camera_trajectory[timestamp];
-
         //Poses are stored in the file in iSAM basis, undo it
         Eigen::Matrix4f M;
         M <<  0,  0, 1, 0,
@@ -78,7 +76,7 @@ Eigen::Matrix4f GroundTruthOdometry::getIncrementalTransformation(uint64_t times
               0, -1, 0, 0,
               0,  0, 0, 1;
 
-        pose = M.inverse() * delta * M;
+        pose = M.inverse() * camera_trajectory[timestamp] * M;
     }
     else
     {

--- a/GUI/src/Tools/GroundTruthOdometry.h
+++ b/GUI/src/Tools/GroundTruthOdometry.h
@@ -36,7 +36,7 @@ class GroundTruthOdometry
 
         virtual ~GroundTruthOdometry();
 
-        Eigen::Matrix4f getIncrementalTransformation(uint64_t timestamp);
+        Eigen::Matrix4f getTransformation(uint64_t timestamp);
 
         Eigen::MatrixXd getCovariance();
 


### PR DESCRIPTION
When using groundTruthOdometry, there is a small bug in MainController.cpp where it obtains an incremental transform with respect to the last pose but uses it like a transform with respect to the world.