### PR TITLE
Bugfix: Fixed reset button works with logs

### DIFF
--- a/GUI/src/MainController.cpp
+++ b/GUI/src/MainController.cpp
@@ -181,6 +181,7 @@ void MainController::launch()
                 delete eFusion;
             }
 
+            logReader->rewind();
             eFusion = new ElasticFusion(openLoop ? std::numeric_limits<int>::max() / 2 : timeDelta,
                                         icpCountThresh,
                                         icpErrThresh,

--- a/GUI/src/Tools/LiveLogReader.h
+++ b/GUI/src/Tools/LiveLogReader.h
@@ -2,16 +2,16 @@
  * This file is part of ElasticFusion.
  *
  * Copyright (C) 2015 Imperial College London
- * 
- * The use of the code within this file and all code within files that 
- * make up the software that is ElasticFusion is permitted for 
- * non-commercial purposes only.  The full terms and conditions that 
- * apply to the code within this file are detailed within the LICENSE.txt 
- * file and at <http://www.imperial.ac.uk/dyson-robotics-lab/downloads/elastic-fusion/elastic-fusion-license/> 
- * unless explicitly stated.  By downloading this file you agree to 
+ *
+ * The use of the code within this file and all code within files that
+ * make up the software that is ElasticFusion is permitted for
+ * non-commercial purposes only.  The full terms and conditions that
+ * apply to the code within this file are detailed within the LICENSE.txt
+ * file and at <http://www.imperial.ac.uk/dyson-robotics-lab/downloads/elastic-fusion/elastic-fusion-license/>
+ * unless explicitly stated.  By downloading this file you agree to
  * comply with these terms.
  *
- * If you wish to use any of this code for commercial purposes then 
+ * If you wish to use any of this code for commercial purposes then
  * please email researchcontracts.engineering@imperial.ac.uk.
  *
  */
@@ -45,6 +45,11 @@ class LiveLogReader : public LogReader
         bool rewound()
         {
             return false;
+        }
+
+        void rewind()
+        {
+
         }
 
         void getBack()

--- a/GUI/src/Tools/LogReader.h
+++ b/GUI/src/Tools/LogReader.h
@@ -2,16 +2,16 @@
  * This file is part of ElasticFusion.
  *
  * Copyright (C) 2015 Imperial College London
- * 
- * The use of the code within this file and all code within files that 
- * make up the software that is ElasticFusion is permitted for 
- * non-commercial purposes only.  The full terms and conditions that 
- * apply to the code within this file are detailed within the LICENSE.txt 
- * file and at <http://www.imperial.ac.uk/dyson-robotics-lab/downloads/elastic-fusion/elastic-fusion-license/> 
- * unless explicitly stated.  By downloading this file you agree to 
+ *
+ * The use of the code within this file and all code within files that
+ * make up the software that is ElasticFusion is permitted for
+ * non-commercial purposes only.  The full terms and conditions that
+ * apply to the code within this file are detailed within the LICENSE.txt
+ * file and at <http://www.imperial.ac.uk/dyson-robotics-lab/downloads/elastic-fusion/elastic-fusion-license/>
+ * unless explicitly stated.  By downloading this file you agree to
  * comply with these terms.
  *
- * If you wish to use any of this code for commercial purposes then 
+ * If you wish to use any of this code for commercial purposes then
  * please email researchcontracts.engineering@imperial.ac.uk.
  *
  */
@@ -54,6 +54,8 @@ class LogReader
         virtual bool hasMore() = 0;
 
         virtual bool rewound() = 0;
+
+        virtual void rewind() = 0;
 
         virtual void getBack() = 0;
 

--- a/GUI/src/Tools/RawLogReader.cpp
+++ b/GUI/src/Tools/RawLogReader.cpp
@@ -147,13 +147,13 @@ bool RawLogReader::hasMore()
 }
 
 
-void RawLogReader::rewind() {
+void RawLogReader::rewind()
+{
     if (filePointers.size() != 0)
     {
         filePointers = {};
     }
 
-    std::cerr << "resetted\n";
     fclose(fp);
     fp = fopen(file.c_str(), "rb");
 

--- a/GUI/src/Tools/RawLogReader.cpp
+++ b/GUI/src/Tools/RawLogReader.cpp
@@ -2,20 +2,20 @@
  * This file is part of ElasticFusion.
  *
  * Copyright (C) 2015 Imperial College London
- * 
- * The use of the code within this file and all code within files that 
- * make up the software that is ElasticFusion is permitted for 
- * non-commercial purposes only.  The full terms and conditions that 
- * apply to the code within this file are detailed within the LICENSE.txt 
- * file and at <http://www.imperial.ac.uk/dyson-robotics-lab/downloads/elastic-fusion/elastic-fusion-license/> 
- * unless explicitly stated.  By downloading this file you agree to 
+ *
+ * The use of the code within this file and all code within files that
+ * make up the software that is ElasticFusion is permitted for
+ * non-commercial purposes only.  The full terms and conditions that
+ * apply to the code within this file are detailed within the LICENSE.txt
+ * file and at <http://www.imperial.ac.uk/dyson-robotics-lab/downloads/elastic-fusion/elastic-fusion-license/>
+ * unless explicitly stated.  By downloading this file you agree to
  * comply with these terms.
  *
- * If you wish to use any of this code for commercial purposes then 
+ * If you wish to use any of this code for commercial purposes then
  * please email researchcontracts.engineering@imperial.ac.uk.
  *
  */
- 
+
 #include "RawLogReader.h"
 
 RawLogReader::RawLogReader(std::string file, bool flipColors)
@@ -146,21 +146,25 @@ bool RawLogReader::hasMore()
     return currentFrame + 1 < numFrames;
 }
 
-bool RawLogReader::rewound()
-{
-    if(filePointers.size() == 0)
+
+void RawLogReader::rewind() {
+    if (filePointers.size() != 0)
     {
-        fclose(fp);
-        fp = fopen(file.c_str(), "rb");
-
-        assert(fread(&numFrames, sizeof(int32_t), 1, fp));
-
-        currentFrame = 0;
-
-        return true;
+        filePointers = {};
     }
 
-    return false;
+    std::cerr << "resetted\n";
+    fclose(fp);
+    fp = fopen(file.c_str(), "rb");
+
+    assert(fread(&numFrames, sizeof(int32_t), 1, fp));
+
+    currentFrame = 0;
+}
+
+bool RawLogReader::rewound()
+{
+    return filePointers.size() == 0;
 }
 
 const std::string RawLogReader::getFile()

--- a/GUI/src/Tools/RawLogReader.h
+++ b/GUI/src/Tools/RawLogReader.h
@@ -2,16 +2,16 @@
  * This file is part of ElasticFusion.
  *
  * Copyright (C) 2015 Imperial College London
- * 
- * The use of the code within this file and all code within files that 
- * make up the software that is ElasticFusion is permitted for 
- * non-commercial purposes only.  The full terms and conditions that 
- * apply to the code within this file are detailed within the LICENSE.txt 
- * file and at <http://www.imperial.ac.uk/dyson-robotics-lab/downloads/elastic-fusion/elastic-fusion-license/> 
- * unless explicitly stated.  By downloading this file you agree to 
+ *
+ * The use of the code within this file and all code within files that
+ * make up the software that is ElasticFusion is permitted for
+ * non-commercial purposes only.  The full terms and conditions that
+ * apply to the code within this file are detailed within the LICENSE.txt
+ * file and at <http://www.imperial.ac.uk/dyson-robotics-lab/downloads/elastic-fusion/elastic-fusion-license/>
+ * unless explicitly stated.  By downloading this file you agree to
  * comply with these terms.
  *
- * If you wish to use any of this code for commercial purposes then 
+ * If you wish to use any of this code for commercial purposes then
  * please email researchcontracts.engineering@imperial.ac.uk.
  *
  */
@@ -48,6 +48,8 @@ class RawLogReader : public LogReader
         bool hasMore();
 
         bool rewound();
+
+        void rewind();
 
         void fastForward(int frame);
 


### PR DESCRIPTION
**Motivation:** When processing offline logs, if I wait until the end of the log, pressing the reset button has no effect.

**Fix:** Rewinding the tape when reset is pressed

**Side effects in the API**: Added new `rewind()` point

**Style changes:**. `rewound()` is an adjective. Adjectives should have NO side effects. There should be no trailing spaces in the files (IDE automatically trimmed them and it's a bit hard to add them all back, if picky about that, I can make the effort)

**Behavior changes** `rewound()` no longer rewinds the tape. It is a pure function now. 

**Tests**: 
* Live - works
* Log - works
* Log with the `-r` option - works

**I was careful about:**
* All usages of `rewound()`

**Attentions:**
- I do not guarantee this does not break something else completely. 