### PR TITLE
Added note about OpenGL context to Core API usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,14 @@ Initialise the static configuration parameters once somewhere at the start of yo
     Intrinsics::getInstance(528, 528, 320, 240);
 ```
 
+Create an OpenGL context before creating an ElasticFusion object, as ElasticFusion uses OpenGL internally. You can do this whatever way you wish, using Pangolin is probably easiest given it's a dependency:
+```cpp
+    pangolin::Params windowParams;
+    windowParams.Set("SAMPLE_BUFFERS", 0);
+    windowParams.Set("SAMPLES", 0);
+    pangolin::CreateWindowAndBind("Main", 1280, 800, windowParams);
+```
+
 Make an ElasticFusion object and start using it:
 ```cpp
     ElasticFusion eFusion;


### PR DESCRIPTION
Related to [issue about segfault when using Core API](https://github.com/mp3guy/ElasticFusion/issues/107) without creating OpenGL context beforehand.