### PR TITLE
Do not skip the last frame

### DIFF
--- a/GUI/src/Tools/RawLogReader.cpp
+++ b/GUI/src/Tools/RawLogReader.cpp
@@ -154,7 +154,7 @@ int RawLogReader::getNumFrames()
 
 bool RawLogReader::hasMore()
 {
-    return currentFrame + 1 < numFrames;
+    return currentFrame < numFrames;
 }
 
 


### PR DESCRIPTION
currentFrame seems to be the index of the next frame which has not been read yet (it starts off at zero and is incremented to one only after the first frame has been read). Thus it seems that the check in RawLogReader::hasMore() is off by one. I didn't test it much, but without this change, the pose for the last frame was missing in the output.